### PR TITLE
test: add loader specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "strapi-community-astro-loader",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "strapi-community-astro-loader",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/qs": "^6.9.18",
@@ -14,9 +14,11 @@
 			},
 			"devDependencies": {
 				"astro": "^5.7.5",
+				"msw": "^2.7.5",
 				"publint": "^0.3.12",
 				"tsup": "^8.4.0",
-				"typescript": "^5.8.3"
+				"typescript": "^5.8.3",
+				"vitest": "^3.1.2"
 			},
 			"peerDependencies": {
 				"astro": "^5.0.0"
@@ -143,6 +145,47 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bundled-es-modules/cookie": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+			"integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cookie": "^0.7.2"
+			}
+		},
+		"node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@bundled-es-modules/statuses": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+			"integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"statuses": "^2.0.1"
+			}
+		},
+		"node_modules/@bundled-es-modules/tough-cookie": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+			"integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@types/tough-cookie": "^4.0.5",
+				"tough-cookie": "^4.1.4"
 			}
 		},
 		"node_modules/@capsizecss/unpack": {
@@ -936,6 +979,160 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
+		"node_modules/@inquirer/confirm": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
+			"integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.10",
+				"@inquirer/type": "^3.0.6"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "10.1.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
+			"integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/figures": "^1.0.11",
+				"@inquirer/type": "^3.0.6",
+				"ansi-escapes": "^4.3.2",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^2.0.0",
+				"signal-exit": "^4.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@inquirer/core/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+			"integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+			"integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1024,6 +1221,49 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@mswjs/interceptors": {
+			"version": "0.37.6",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+			"integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@open-draft/deferred-promise": "^2.2.0",
+				"@open-draft/logger": "^0.3.0",
+				"@open-draft/until": "^2.0.0",
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.3",
+				"strict-event-emitter": "^0.5.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@open-draft/deferred-promise": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+			"integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@open-draft/logger": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+			"integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.0"
+			}
+		},
+		"node_modules/@open-draft/until": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+			"integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@oslojs/encoding": {
 			"version": "1.1.0",
@@ -1462,6 +1702,13 @@
 				"tslib": "^2.8.0"
 			}
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1522,6 +1769,20 @@
 			"integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/statuses": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+			"integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1535,6 +1796,119 @@
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
+			"integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.1.2",
+				"@vitest/utils": "3.1.2",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
+			"integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.1.2",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+			"integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
+			"integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.1.2",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
+			"integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.1.2",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
+			"integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^3.0.2"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
+			"integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.1.2",
+				"loupe": "^3.1.3",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
 		},
 		"node_modules/acorn": {
 			"version": "8.14.1",
@@ -1602,6 +1976,35 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-escapes/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -1673,6 +2076,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/astro": {
@@ -1983,6 +2396,23 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/chai": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+			"integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
@@ -2027,6 +2457,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2074,6 +2514,110 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -2107,12 +2651,25 @@
 				"node": ">=12.5.0"
 			}
 		},
-		"node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
-			"optional": true
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/color-string": {
 			"version": "1.9.1",
@@ -2124,26 +2681,6 @@
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
 			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"optional": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"optional": true
 		},
 		"node_modules/comma-separated-tokens": {
 			"version": "2.0.3",
@@ -2289,6 +2826,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/defu": {
@@ -2533,6 +3080,16 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/escape-string-regexp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2561,6 +3118,16 @@
 			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/expect-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+			"integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -2642,6 +3209,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
 		"node_modules/get-east-asian-width": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
@@ -2709,6 +3286,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graphql": {
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+			"integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
 		},
 		"node_modules/h3": {
@@ -2951,6 +3538,13 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/headers-polyfill": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/html-escaper": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3045,6 +3639,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/is-node-process": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+			"integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-plain-obj": {
 			"version": "4.1.0",
@@ -3170,6 +3771,13 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/loupe": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+			"integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
 			"version": "10.4.3",
@@ -4089,6 +4697,61 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
 		},
+		"node_modules/msw": {
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-2.7.5.tgz",
+			"integrity": "sha512-00MyTlY3TJutBa5kiU+jWiz2z5pNJDYHn2TgPkGkh92kMmNH43RqvMXd8y/7HxNn8RjzUbvZWYZjcS36fdb6sw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bundled-es-modules/cookie": "^2.0.1",
+				"@bundled-es-modules/statuses": "^1.0.1",
+				"@bundled-es-modules/tough-cookie": "^0.1.6",
+				"@inquirer/confirm": "^5.0.0",
+				"@mswjs/interceptors": "^0.37.0",
+				"@open-draft/deferred-promise": "^2.2.0",
+				"@open-draft/until": "^2.1.0",
+				"@types/cookie": "^0.6.0",
+				"@types/statuses": "^2.0.4",
+				"graphql": "^16.8.1",
+				"headers-polyfill": "^4.0.2",
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.3",
+				"path-to-regexp": "^6.3.0",
+				"picocolors": "^1.1.1",
+				"strict-event-emitter": "^0.5.1",
+				"type-fest": "^4.26.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"msw": "cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mswjs"
+			},
+			"peerDependencies": {
+				"typescript": ">= 4.8.x"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/mute-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
 		"node_modules/mz": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -4271,6 +4934,13 @@
 				"regex-recursion": "^6.0.2"
 			}
 		},
+		"node_modules/outvariant": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+			"integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/p-limit": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -4392,6 +5062,30 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+			"integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
 			}
 		},
 		"node_modules/picocolors": {
@@ -4536,6 +5230,19 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
+			}
+		},
 		"node_modules/publint": {
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/publint/-/publint-0.3.12.tgz",
@@ -4581,6 +5288,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/radix3": {
 			"version": "1.1.2",
@@ -4780,6 +5494,23 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
@@ -5077,6 +5808,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5149,6 +5887,37 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/statuses": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/std-env": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/strict-event-emitter": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+			"integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "7.2.0",
@@ -5347,6 +6116,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinyexec": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -5399,6 +6175,36 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/tinypool": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+			"integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+			"integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5406,6 +6212,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/tr46": {
@@ -5767,6 +6589,16 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/unstorage": {
 			"version": "1.15.0",
 			"resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.15.0.tgz",
@@ -5858,6 +6690,17 @@
 				"uploadthing": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/vfile": {
@@ -5980,6 +6823,29 @@
 				}
 			}
 		},
+		"node_modules/vite-node": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
+			"integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.0",
+				"es-module-lexer": "^1.6.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/vite/node_modules/fdir": {
 			"version": "6.4.4",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
@@ -6023,6 +6889,77 @@
 			},
 			"peerDependenciesMeta": {
 				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
+			"integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "3.1.2",
+				"@vitest/mocker": "3.1.2",
+				"@vitest/pretty-format": "^3.1.2",
+				"@vitest/runner": "3.1.2",
+				"@vitest/snapshot": "3.1.2",
+				"@vitest/spy": "3.1.2",
+				"@vitest/utils": "3.1.2",
+				"chai": "^5.2.0",
+				"debug": "^4.4.0",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.13",
+				"tinypool": "^1.0.2",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0",
+				"vite-node": "3.1.2",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.1.2",
+				"@vitest/ui": "3.1.2",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
 					"optional": true
 				}
 			}
@@ -6078,6 +7015,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/widest-line": {
@@ -6155,24 +7109,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
 		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -6235,6 +7171,35 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/yargs-parser": {
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -6242,6 +7207,51 @@
 			"dev": true,
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -6277,6 +7287,19 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
 			"integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
 		"build": "tsup src/index.ts --format esm --dts --clean",
 		"dev": "tsup src/index.ts --format esm --dts --watch",
 		"check": "publint && attw $(pnpm pack) --ignore-rules=cjs-resolves-to-esm",
-		"test": "vitest"
+		"test": "vitest --run"
 	},
 	"devDependencies": {
 		"astro": "^5.7.5",
+		"msw": "^2.7.5",
 		"publint": "^0.3.12",
 		"tsup": "^8.4.0",
-		"typescript": "^5.8.3"
+		"typescript": "^5.8.3",
+		"vitest": "^3.1.2"
 	},
 	"peerDependencies": {
 		"astro": "^5.0.0"

--- a/src/astro-loader.test.ts
+++ b/src/astro-loader.test.ts
@@ -1,0 +1,77 @@
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {strapiLoader} from "./astro-loader";
+import type {Loader, LoaderContext} from "astro/loaders";
+import {mockLoaderContext, PAGES, server, TYPE} from "./test.utils";
+
+describe('#load', () => {
+    const ONE_SECOND = 1000
+    const TEN_SECONDS = ONE_SECOND * 10
+    const THIRTY_SECONDS = ONE_SECOND * 30
+    let loader: Loader
+    let context: LoaderContext
+
+    // TODO: move to setup-test
+    beforeAll(() => {
+        server.listen()
+    })
+
+    afterEach(() => {
+        server.resetHandlers()
+    })
+
+    afterAll(() => {
+        server.close()
+    })
+
+    it('should name loader based on content type', () => {
+        const expectedLoaderName = 'strapi-testType';
+        const {name} = strapiLoader({contentType: TYPE})
+        expect(name).toEqual(expectedLoaderName)
+    })
+
+    describe('with recent sync', async () => {
+        beforeEach(() => {
+            // TODO: mock Date.now
+            const tenSecondsAgo = Date.now() - TEN_SECONDS
+            context = mockLoaderContext({lastSynced: String(tenSecondsAgo)})
+            loader = strapiLoader({contentType: TYPE, syncInterval: THIRTY_SECONDS})
+        })
+
+        it('should skip syncing if it was recently synced', async () => {
+            await loader.load(context)
+            expect(context.store.clear).not.toHaveBeenCalled()
+            expect(context.store.set).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('with stale sync', async () => {
+        beforeEach(() => {
+            // TODO: mock Date.now
+            const thirtySecondsAgo = Date.now() - THIRTY_SECONDS
+            context = mockLoaderContext({lastSynced: String(thirtySecondsAgo)})
+            loader = strapiLoader({contentType: TYPE, syncInterval: TEN_SECONDS})
+        })
+
+        it('should fetch content types', async () => {
+            const expectedDataStoreEntries = PAGES.map(page => ({
+                id: page.id,
+                data: page
+            }))
+            await loader.load(context)
+            expect(context.store.clear).toHaveBeenCalledOnce()
+            expect(context.store.set).toHaveBeenCalledTimes(PAGES.length)
+            expect(context.store.set).toHaveBeenNthCalledWith(1, expectedDataStoreEntries[0])
+            expect(context.store.set).toHaveBeenNthCalledWith(2, expectedDataStoreEntries[1])
+            expect(context.meta.set).toHaveBeenCalledExactlyOnceWith("lastSynced", expect.any(String))
+        })
+    })
+
+    describe('without previous sync', async () => {
+        beforeEach(() => {
+            context = mockLoaderContext()
+            loader = strapiLoader({contentType: TYPE})
+        })
+
+        it.todo('in theory, we should do every test from the stale sync scenario.')
+    })
+})

--- a/src/test.utils.ts
+++ b/src/test.utils.ts
@@ -1,0 +1,68 @@
+import type {LoaderContext} from "astro/loaders";
+import {vi} from "vitest";
+import {http, HttpResponse} from 'msw'
+import {setupServer} from "msw/node";
+
+export function mockLoaderContext(config?: { lastSynced?: string }): LoaderContext {
+    return {
+        store: {
+            clear: vi.fn(),
+            set: vi.fn()
+        },
+        meta: {
+            get: vi.fn((key: string) => key === 'lastSynced' ? config?.lastSynced : undefined),
+            set: vi.fn(),
+            has: vi.fn(),
+            delete: vi.fn(),
+        },
+        logger: {
+            info: vi.fn(),
+            error: vi.fn(),
+        }
+    } as unknown as LoaderContext
+}
+
+
+export function handlers(url: string, contentTypes: Record<string, object>) {
+    return Object.keys(contentTypes).map(contentType => {
+        const contentTypeUrl = `${url}/api/${contentType}s`
+        const schemaUrl = `${url}/get-strapi-schema/schema/${contentType}`
+        return [
+            http.get(contentTypeUrl, () => {
+                return HttpResponse.json({data: contentTypes[contentType]})
+            }),
+            // TODO: what does this return?
+            http.get(schemaUrl, () => {
+                return HttpResponse.json({attributes: {}})
+            }),
+        ]
+    }).flat()
+}
+
+const ABOUT_PAGE = {
+    id: 6,
+    documentId: "gny2yrqho5t9o4okxjqlpwqn",
+    title: "About",
+    description: "About page.",
+    slug: "about",
+    createdAt: "2025-03-05T19:13:40.938Z",
+    updatedAt: "2025-04-26T20:18:50.480Z",
+    publishedAt: "2025-04-26T20:18:50.488Z"
+};
+const COMPANY_PAGE = {
+    id: 4,
+    documentId: "dje64j42rlsry0p7lpnt87nb",
+    title: "Our Company",
+    description: "This will be page about our company.",
+    slug: "our-company",
+    createdAt: "2025-04-12T04:11:15.114Z",
+    updatedAt: "2025-04-12T04:11:15.114Z",
+    publishedAt: "2025-04-12T04:11:15.122Z"
+};
+export const PAGES = [
+    COMPANY_PAGE,
+    ABOUT_PAGE
+]
+const BASE_URL = "http://localhost:1337";
+export const TYPE = "testType";
+export const server = setupServer(...handlers(BASE_URL, {[TYPE]: PAGES}))


### PR DESCRIPTION
# What this does
- Adds some basic tests around the loader.
- Uses MSW to mock the web traffic the loader triggers. 
- It does not handle schema-specific logic. (I don't fully grok that right now.)


## Notes
- I think some refactoring of the code itself could help both the tests and the code read better, but I want to make sure I'm groking the lib better before attempting to do refactoring. As a result, everything is tested directly through the loader; some refactoring could make more specific tests that would be easier to grok.
- I wasn't able to figure out the schema logic. The `get-strapi-schema/schema` endpoint 404s for me. 
    - It looks like what is published on [npm](https://www.npmjs.com/package/strapi-community-astro-loader-v2?activeTab=code) is slightly diff than what's on [main](https://github.com/PaulBratslavsky/strapi-community-astro-loader/blob/37219dacaaf9d092c38c2ee59cc6299437458adf/src/astro-loader.ts#L122), hence why what's published works locally for me. (What's on npm seems to use the strapi client lib instead of fetching directly.)
- If you're good with me adding more to the lib, I can add `prettier` (or whatever other tool you prefer) to make the code reviews less lint-focused.
- I want to look at other loaders and see how they do testing. I'd imagine there are better ways to mock the `LoaderContext`.

# Why am I even digging around in this lib
- Because it's cool. 
- I was investigating Astro's expanded v5 content functionality and how it operates in a SSR env (as opposed to SSG). Your [demo vid](https://youtu.be/Ud9obEHadLI) points out how the SSG means you have to rebuild every time you change something in the CMS. For a while I was thinking there was some Astro magic to make it more real time and was using this as a test case. 
    - (For closure: There's not _loader_ magic as far as I can tell, but some SSR-related things you can do that are likely out of the scope of your project.)